### PR TITLE
Add gdal to fix cartopy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Swarm_quicklooks
 Notebooks run on a schedule to display recent Swarm data
+

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - scipy
   - xarray
   - matplotlib
+  - gdal
   - cartopy
   - cdflib
   - pip


### PR DESCRIPTION
Geospatial libs are horrible... this seems to alleviate the issue where proj is not linked.